### PR TITLE
Legend item wrap with layout.legend.orientation = h

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -584,13 +584,12 @@ function computeLegendDimensions(gd, groups, traces) {
                 opts.height = opts.height + maxTraceHeight;
             }
 
-            opts.width += traceGap + traceWidth;
-            opts.height = Math.max(opts.height, legendItem.height);
-
             Lib.setTranslate(this,
                 (borderwidth + startX),
                 (5 + borderwidth + legendItem.height / 2) + rowHeight);
 
+            opts.width += traceGap + traceWidth;
+            opts.height = Math.max(opts.height, legendItem.height);
 
             //keep track of tallest trace in group
             startX += traceGap + traceWidth;

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -568,18 +568,33 @@ function computeLegendDimensions(gd, groups, traces) {
     else {
         opts.width = 0;
         opts.height = 0;
+        var rowHeight = 0;
+        var maxTraceHeight = 0;
+        var startX = 0;
 
         traces.each(function(d) {
+
             var legendItem = d[0],
                 traceWidth = 40 + legendItem.width,
                 traceGap = opts.tracegroupgap || 5;
 
-            Lib.setTranslate(this,
-                (borderwidth + opts.width),
-                (5 + borderwidth + legendItem.height / 2));
+            if((borderwidth + startX + traceGap + traceWidth) > fullLayout.width - fullLayout.margin.r) {
+              startX = 0;
+              rowHeight = rowHeight + maxTraceHeight;
+              opts.height = opts.height + maxTraceHeight;
+            }
 
             opts.width += traceGap + traceWidth;
             opts.height = Math.max(opts.height, legendItem.height);
+
+            Lib.setTranslate(this,
+                (borderwidth + startX),
+                (5 + borderwidth + legendItem.height / 2) + rowHeight);
+
+
+            //keep track of tallest trace in group
+            startX += traceGap + traceWidth;
+            maxTraceHeight = (legendItem.height > maxTraceHeight) ? legendItem.height : maxTraceHeight;
         });
 
         opts.width += borderwidth * 2;

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -570,12 +570,18 @@ function computeLegendDimensions(gd, groups, traces) {
         opts.height = 0;
         var rowHeight = 0,
             maxTraceHeight = 0,
+            maxTraceWidth = 0,
             offsetX = 0;
+
+        //calculate largest width for traces and use for width of all legend items
+        traces.each(function(d) {
+          maxTraceWidth = Math.max(40 + d[0].width, maxTraceWidth);
+        });
 
         traces.each(function(d) {
 
             var legendItem = d[0],
-                traceWidth = 40 + legendItem.width,
+                traceWidth = maxTraceWidth,
                 traceGap = opts.tracegroupgap || 5;
 
             if((borderwidth + offsetX + traceGap + traceWidth) > (fullLayout.width - (fullLayout.margin.r + fullLayout.margin.l))) {

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -578,7 +578,7 @@ function computeLegendDimensions(gd, groups, traces) {
                 traceWidth = 40 + legendItem.width,
                 traceGap = opts.tracegroupgap || 5;
 
-            if((borderwidth + offsetX + traceGap + traceWidth) > fullLayout.width - fullLayout.margin.r) {
+            if((borderwidth + offsetX + traceGap + traceWidth) > (fullLayout.width - (fullLayout.margin.r + fullLayout.margin.l))) {
                 offsetX = 0;
                 rowHeight = rowHeight + maxTraceHeight;
                 opts.height = opts.height + maxTraceHeight;

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -568,9 +568,9 @@ function computeLegendDimensions(gd, groups, traces) {
     else {
         opts.width = 0;
         opts.height = 0;
-        var rowHeight = 0;
-        var maxTraceHeight = 0;
-        var startX = 0;
+        var rowHeight = 0,
+            maxTraceHeight = 0,
+            offsetX = 0;
 
         traces.each(function(d) {
 
@@ -578,22 +578,24 @@ function computeLegendDimensions(gd, groups, traces) {
                 traceWidth = 40 + legendItem.width,
                 traceGap = opts.tracegroupgap || 5;
 
-            if((borderwidth + startX + traceGap + traceWidth) > fullLayout.width - fullLayout.margin.r) {
-                startX = 0;
+            if((borderwidth + offsetX + traceGap + traceWidth) > fullLayout.width - fullLayout.margin.r) {
+                offsetX = 0;
                 rowHeight = rowHeight + maxTraceHeight;
                 opts.height = opts.height + maxTraceHeight;
+                //reset for next row
+                maxTraceHeight = 0;
             }
 
             Lib.setTranslate(this,
-                (borderwidth + startX),
+                (borderwidth + offsetX),
                 (5 + borderwidth + legendItem.height / 2) + rowHeight);
 
             opts.width += traceGap + traceWidth;
             opts.height = Math.max(opts.height, legendItem.height);
 
             //keep track of tallest trace in group
-            startX += traceGap + traceWidth;
-            maxTraceHeight = (legendItem.height > maxTraceHeight) ? legendItem.height : maxTraceHeight;
+            offsetX += traceGap + traceWidth;
+            maxTraceHeight = Math.max(legendItem.height, maxTraceHeight);
         });
 
         opts.width += borderwidth * 2;

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -579,9 +579,9 @@ function computeLegendDimensions(gd, groups, traces) {
                 traceGap = opts.tracegroupgap || 5;
 
             if((borderwidth + startX + traceGap + traceWidth) > fullLayout.width - fullLayout.margin.r) {
-              startX = 0;
-              rowHeight = rowHeight + maxTraceHeight;
-              opts.height = opts.height + maxTraceHeight;
+                startX = 0;
+                rowHeight = rowHeight + maxTraceHeight;
+                opts.height = opts.height + maxTraceHeight;
             }
 
             opts.width += traceGap + traceWidth;


### PR DESCRIPTION
Should help with #769:
1. Keeps track of tallest legend item in list.
2. Calculates the upcoming width of the legend item and sees if it will push the item past the right margin.
3. If it will be pushed out of viewable range, creates a new row of legend items based on the previous rows tallest legend item.
