### PR TITLE
Horizontal legend in columns

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -570,12 +570,18 @@ function computeLegendDimensions(gd, groups, traces) {
         opts.height = 0;
         var rowHeight = 0,
             maxTraceHeight = 0,
+            maxTraceWidth = 0,
             offsetX = 0;
+
+        //calculate largest width for traces and use for width of all legend items
+        traces.each(function(d) {
+          maxTraceWidth = Math.max(40 + d[0].width, maxTraceWidth);
+        });
 
         traces.each(function(d) {
 
             var legendItem = d[0],
-                traceWidth = 40 + legendItem.width,
+                traceWidth = maxTraceWidth,
                 traceGap = opts.tracegroupgap || 5;
 
             if((borderwidth + offsetX + traceGap + traceWidth) > (fullLayout.width - (fullLayout.margin.r + fullLayout.margin.l))) {


### PR DESCRIPTION
What do you think @n-riesco? This should work?

I've found that legend positioning has issues with the graph I've been testing when `layout.width < 780` but I I'm pretty sure it's related to something else, not an issue with this section rendering the legend.

![newplot 2](https://cloud.githubusercontent.com/assets/12420157/17149251/f4dbd0c6-5316-11e6-9600-65a0e3eac18e.png)
